### PR TITLE
Arreglando interaccion entre las pilas

### DIFF
--- a/cpp/karel.h
+++ b/cpp/karel.h
@@ -38,6 +38,14 @@ enum class Opcode : uint32_t {
   PARAM
 };
 
+constexpr const char* kOpcodeNames[] = {
+    "HALT",    "LINE",         "LEFT",       "WORLDWALLS", "ORIENTATION",
+    "ROTL",    "ROTR",         "MASK",       "NOT",        "AND",
+    "OR",      "EQ",           "EZ",         "JZ",         "JMP",
+    "FORWARD", "WORLDBUZZERS", "BAGBUZZERS", "PICKBUZZER", "LEAVEBUZZER",
+    "LOAD",    "POP",          "DUP",        "DEC",        "INC",
+    "CALL",    "RET",          "PARAM"};
+
 struct Instruction {
   Opcode opcode = Opcode::HALT;
   int32_t arg = 0;

--- a/js/karel.js
+++ b/js/karel.js
@@ -532,6 +532,8 @@ Runtime.prototype.next = function() {
       var copy = {
         pc: self.state.pc,
         stackSize: self.state.stackSize,
+        expressionStack: Array.from(
+            self.state.stack.slice(self.state.fp + 4, self.state.sp + 1)),
         line: self.state.line,
         ic: self.state.ic,
         running: self.state.running


### PR DESCRIPTION
Este cambio arregla una interacción rara entre las pilas de función y
expresión. Esto ocurría si tenías una función con un ciclo (con un
número explícito de iteraciones) invoca una función, esa función tiene
otro ciclo y dentro de este ciclo se llama sal-de-instruccion.