### PR TITLE
Permitiendo usar `-` como archivo de salida para `cmd/kareljs draw`

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -14,7 +14,10 @@ var Draw = function (worldString, outputFile, opts) {
 
   var worldXml = new DOMParser().parseFromString(worldString, 'text/xml');
 
-  var out = fs.createWriteStream(outputFile, { encoding: 'binary' });
+  var out =
+    outputFile == '-' || outputFile == '/dev/stdout'
+      ? process.stdout
+      : fs.createWriteStream(outputFile, { encoding: 'binary' });
   var doneWriting = new Promise((resolve) => out.on('finish', resolve));
 
   var world = new karel.World(100, 100);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karel",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Compilador y evaluador de Karel en javascript",
   "main": "js/index.js",
   "scripts": {


### PR DESCRIPTION
Este cambio permite que se escriba el png a salida estándar. Esto
facilita correr este binario en un contenedor sin tener que hacer
manipulaciones locas de volúmenes.