### PR TITLE
Using a node version compatible with canvas in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ jobs:
   release:
     runs-on: ubuntu-22.04
 
+    strategy:
+      matrix:
+        node-version: [16.x]
+
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Downgrade de node version because a critical bug in the version 17.

Refer: https://github.com/webpack/webpack/issues/14532